### PR TITLE
Fixup Zlib typings to match Node docs

### DIFF
--- a/0.10/node.d.ts
+++ b/0.10/node.d.ts
@@ -483,6 +483,7 @@ declare module "cluster" {
 declare module "zlib" {
     import stream = require("stream");
     export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
+    export interface ZlibCallback { (error: Error, result: any): void }
 
     export interface Gzip extends stream.Transform { }
     export interface Gunzip extends stream.Transform { }
@@ -500,13 +501,13 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function deflate(buf: Buffer | string, callback: ZlibCallback): void;
+    export function deflateRaw(buf: Buffer | string, callback: ZlibCallback): void;
+    export function gzip(buf: Buffer | string, callback: ZlibCallback): void;
+    export function gunzip(buf: Buffer | string, callback: ZlibCallback): void;
+    export function inflate(buf: Buffer | string, callback: ZlibCallback): void;
+    export function inflateRaw(buf: Buffer | string, callback: ZlibCallback): void;
+    export function unzip(buf: Buffer | string, callback: ZlibCallback): void;
 
     // Constants
     export var Z_NO_FLUSH: number;

--- a/0.11/node.d.ts
+++ b/0.11/node.d.ts
@@ -406,6 +406,7 @@ declare module "cluster" {
 declare module "zlib" {
     import stream = require("stream");
     export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
+    export interface ZlibCallback { (error: Error, result: any): void }
 
     export interface Gzip extends stream.Transform { }
     export interface Gunzip extends stream.Transform { }
@@ -423,13 +424,13 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function deflate(buf: Buffer | string, callback: ZlibCallback): void;
+    export function deflateRaw(buf: Buffer | string, callback: ZlibCallback): void;
+    export function gzip(buf: Buffer | string, callback: ZlibCallback): void;
+    export function gunzip(buf: Buffer | string, callback: ZlibCallback): void;
+    export function inflate(buf: Buffer | string, callback: ZlibCallback): void;
+    export function inflateRaw(buf: Buffer | string, callback: ZlibCallback): void;
+    export function unzip(buf: Buffer | string, callback: ZlibCallback): void;
 
     // Constants
     export var Z_NO_FLUSH: number;

--- a/0.12/node.d.ts
+++ b/0.12/node.d.ts
@@ -616,6 +616,7 @@ declare module "cluster" {
 declare module "zlib" {
     import * as stream from "stream";
     export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
+    export interface ZlibCallback { (error: Error, result: any): void }
 
     export interface Gzip extends stream.Transform { }
     export interface Gunzip extends stream.Transform { }
@@ -633,20 +634,27 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateSync(buf: Buffer, options?: ZlibOptions): any;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateRawSync(buf: Buffer, options?: ZlibOptions): any;
-    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gzipSync(buf: Buffer, options?: ZlibOptions): any;
-    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gunzipSync(buf: Buffer, options?: ZlibOptions): any;
-    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateSync(buf: Buffer, options?: ZlibOptions): any;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateRawSync(buf: Buffer, options?: ZlibOptions): any;
-    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function unzipSync(buf: Buffer, options?: ZlibOptions): any;
+    export function deflate(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function deflate(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
+    export function deflateSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function deflateRaw(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function deflateRaw(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
+    export function deflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function gzip(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function gzip(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
+    export function gzipSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function gunzip(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function gunzip(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
+    export function gunzipSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function inflate(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function inflate(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
+    export function inflateSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function inflateRaw(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function inflateRaw(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
+    export function inflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function unzip(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function unzip(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
+    export function unzipSync(buf: Buffer | string, options?: ZlibOptions): any;
 
     // Constants
     export var Z_NO_FLUSH: number;

--- a/0.8/node.d.ts
+++ b/0.8/node.d.ts
@@ -340,6 +340,7 @@ declare module "cluster" {
 declare module "zlib" {
     import stream = require("stream");
     export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
+    export interface ZlibCallback { (error: Error, result: any): void }
 
     export interface Gzip extends stream.ReadWriteStream { }
     export interface Gunzip extends stream.ReadWriteStream { }
@@ -357,13 +358,13 @@ declare module "zlib" {
     export function createInflateRaw(options: ZlibOptions): InflateRaw;
     export function createUnzip(options: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result) =>void ): void;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result) =>void ): void;
-    export function gzip(buf: Buffer, callback: (error: Error, result) =>void ): void;
-    export function gunzip(buf: Buffer, callback: (error: Error, result) =>void ): void;
-    export function inflate(buf: Buffer, callback: (error: Error, result) =>void ): void;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result) =>void ): void;
-    export function unzip(buf: Buffer, callback: (error: Error, result) =>void ): void;
+    export function deflate(buf: Buffer, callback: ZlibCallback): void;
+    export function deflateRaw(buf: Buffer, callback: ZlibCallback): void;
+    export function gzip(buf: Buffer, callback: ZlibCallback): void;
+    export function gunzip(buf: Buffer, callback: ZlibCallback): void;
+    export function inflate(buf: Buffer, callback: ZlibCallback): void;
+    export function inflateRaw(buf: Buffer, callback: ZlibCallback): void;
+    export function unzip(buf: Buffer, callback: ZlibCallback): void;
 
     // Constants
     export var Z_NO_FLUSH: number;

--- a/4/node.d.ts
+++ b/4/node.d.ts
@@ -764,6 +764,7 @@ declare module "cluster" {
 declare module "zlib" {
     import * as stream from "stream";
     export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
+    export interface ZlibCallback { (error: Error, result: any): void }
 
     export interface Gzip extends stream.Transform { }
     export interface Gunzip extends stream.Transform { }
@@ -781,20 +782,20 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateSync(buf: Buffer, options?: ZlibOptions): any;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateRawSync(buf: Buffer, options?: ZlibOptions): any;
-    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gzipSync(buf: Buffer, options?: ZlibOptions): any;
-    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gunzipSync(buf: Buffer, options?: ZlibOptions): any;
-    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateSync(buf: Buffer, options?: ZlibOptions): any;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateRawSync(buf: Buffer, options?: ZlibOptions): any;
-    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function unzipSync(buf: Buffer, options?: ZlibOptions): any;
+    export function deflate(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function deflateSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function deflateRaw(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function deflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function gzip(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function gzipSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function gunzip(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function gunzipSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function inflate(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function inflateSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function inflateRaw(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function inflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function unzip(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function unzipSync(buf: Buffer | string, options?: ZlibOptions): any;
 
     // Constants
     export var Z_NO_FLUSH: number;

--- a/4/node.d.ts
+++ b/4/node.d.ts
@@ -782,19 +782,26 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function deflate(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function deflate(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
     export function deflateSync(buf: Buffer | string, options?: ZlibOptions): any;
-    export function deflateRaw(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function deflateRaw(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function deflateRaw(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
     export function deflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
-    export function gzip(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function gzip(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function gzip(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
     export function gzipSync(buf: Buffer | string, options?: ZlibOptions): any;
-    export function gunzip(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function gunzip(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function gunzip(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
     export function gunzipSync(buf: Buffer | string, options?: ZlibOptions): any;
-    export function inflate(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function inflate(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function inflate(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
     export function inflateSync(buf: Buffer | string, options?: ZlibOptions): any;
-    export function inflateRaw(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function inflateRaw(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function inflateRaw(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
     export function inflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
-    export function unzip(buf: Buffer | string, options: ZlibOptions | ZlibCallback, callback?: ZlibCallback): void;
+    export function unzip(buf: Buffer | string, callback?: ZlibCallback): void;
+    export function unzip(buf: Buffer | string, options: ZlibOptions, callback?: ZlibCallback): void;
     export function unzipSync(buf: Buffer | string, options?: ZlibOptions): any;
 
     // Constants


### PR DESCRIPTION
 * Zlib functions can accept Buffer or string as first argument

 * async functions take optional second argument `options`

 * make interface ZlibCallback to shorthand all the async callbacks declarations