### PR TITLE
Refactored connection options

### DIFF
--- a/0.10/node.d.ts
+++ b/0.10/node.d.ts
@@ -412,7 +412,7 @@ declare module "http" {
 		/**
 		 * Port of remote server. Defaults to 80.
 		 */
-		port?: number;
+		port?: number | string;
 		/**
 		 * Local interface to bind for network connections.
 		 */
@@ -432,7 +432,7 @@ declare module "http" {
 		/**
 		 * An object containing request headers.
 		 */
-		headers?: { [index: string]: string };
+		headers?: { [index: string]: any };
 		/**
 		 * Basic authentication i.e. 'user:password' to compute an Authorization header.
 		 */
@@ -443,7 +443,7 @@ declare module "http" {
 		 * - Agent object: explicitly use the passed in Agent.
 		 * - false: opts out of connection pooling with an Agent, defaults request to Connection: close.
 		 */
-		agent?: Agent|boolean;
+		agent?: Agent | boolean;
 	}
 
     export var STATUS_CODES: {
@@ -452,8 +452,8 @@ declare module "http" {
     };
     export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: RequestOptions, callback?: (response: ClientResponse) => void): ClientRequest;
-    export function get(options: RequestOptions, callback?: (response: ClientResponse) => void): ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (response: ClientResponse) => void): ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (response: ClientResponse) => void): ClientRequest;
     export var globalAgent: Agent;
 }
 declare module "cluster" {
@@ -595,20 +595,12 @@ declare module "https" {
         SNICallback?: (servername: string) => any;
     }
 
-    export interface RequestOptions {
-        host?: string;
-        hostname?: string;
-        port?: number;
-        path?: string;
-        method?: string;
-        headers?: any;
-        auth?: string;
-        agent?: any;
-        pfx?: any;
-        key?: any;
+    export interface RequestOptions extends http.RequestOptions {
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         ciphers?: string;
         rejectUnauthorized?: boolean;
     }
@@ -623,8 +615,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -757,7 +749,7 @@ declare module "url" {
         host?: string;
         pathname?: string;
         search?: string;
-        query?: any; // string | Object
+        query?: string | any;
         slashes?: boolean;
         hash?: string;
         path?: string;
@@ -1065,31 +1057,31 @@ declare module "tls" {
     var CLIENT_RENEG_WINDOW: number;
 
     export interface TlsOptions {
-        pfx?: any;   //string or buffer
-        key?: any;   //string or buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;    //string or buffer
-        crl?: any;   //string or string array
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: any;
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //array or Buffer;
+        NPNProtocols?: Array<string | Buffer>;
         SNICallback?: (servername: string) => any;
     }
 
     export interface ConnectionOptions {
         host?: string;
-        port?: number;
+        port?: number | string;
         socket?: net.Socket;
-        pfx?: any;   //string | Buffer
-        key?: any;   //string | Buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;  //string | Buffer
-        ca?: any;    //Array of string | Buffer
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //Array of string | Buffer
+        NPNProtocols?: Array<string | Buffer>;
         servername?: string;
     }
 

--- a/0.11/node.d.ts
+++ b/0.11/node.d.ts
@@ -291,6 +291,55 @@ declare module "http" {
     import net = require("net");
     import stream = require("stream");
 
+    /**
+     * Options for http.request()
+    */
+    export interface RequestOptions {
+        /**
+         * A domain name or IP address of the server to issue the request to. Defaults to 'localhost'.
+         */
+        host?: string;
+        /**
+         * To support url.parse() hostname is preferred over host
+         */
+        hostname?: string;
+        /**
+         * Port of remote server. Defaults to 80.
+         */
+        port?: number | string;
+        /**
+         * Local interface to bind for network connections.
+         */
+        localAddress?: string;
+        /**
+         * Unix Domain Socket (use one of host:port or socketPath)
+         */
+        socketPath?: string;
+        /**
+         * A string specifying the HTTP request method. Defaults to 'GET'.
+         */
+        method?: string;
+        /**
+         * Request path. Defaults to '/'. Should include query string if any. E.G. '/index.html?page=12'
+         */
+        path?: string;
+        /**
+         * An object containing request headers.
+         */
+        headers?: { [index: string]: any };
+        /**
+         * Basic authentication i.e. 'user:password' to compute an Authorization header.
+         */
+        auth?: string;
+        /**
+         * Controls Agent behavior. When an Agent is used request will default to Connection: keep-alive. Possible values:
+         * - undefined (default): use global Agent for this host and port.
+         * - Agent object: explicitly use the passed in Agent.
+         * - false: opts out of connection pooling with an Agent, defaults request to Connection: close.
+         */
+        agent?: Agent | boolean;
+    }
+
     export interface Server extends events.EventEmitter {
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
         listen(path: string, callback?: Function): Server;
@@ -374,8 +423,8 @@ declare module "http" {
     };
     export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: any, callback?: Function): ClientRequest;
-    export function get(options: any, callback?: Function): ClientRequest;
+    export function request(options: string | RequestOptions, callback?: Function): ClientRequest;
+    export function get(options: string | RequestOptions, callback?: Function): ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -518,20 +567,12 @@ declare module "https" {
         SNICallback?: (servername: string) => any;
     }
 
-    export interface RequestOptions {
-        host?: string;
-        hostname?: string;
-        port?: number;
-        path?: string;
-        method?: string;
-        headers?: any;
-        auth?: string;
-        agent?: any;
-        pfx?: any;
-        key?: any;
+    export interface RequestOptions extends http.RequestOptions {
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         ciphers?: string;
         rejectUnauthorized?: boolean;
     }
@@ -546,8 +587,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -676,7 +717,7 @@ declare module "url" {
         host?: string;
         pathname?: string;
         search?: string;
-        query?: any; // string | Object
+        query?: string | any;
         slashes?: boolean;
         hash?: string;
         path?: string;
@@ -976,31 +1017,31 @@ declare module "tls" {
     var CLIENT_RENEG_WINDOW: number;
 
     export interface TlsOptions {
-        pfx?: any;   //string or buffer
-        key?: any;   //string or buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;    //string or buffer
-        crl?: any;   //string or string array
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: any;
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //array or Buffer;
+        NPNProtocols?: Array<string | Buffer>;
         SNICallback?: (servername: string) => any;
     }
 
     export interface ConnectionOptions {
         host?: string;
-        port?: number;
+        port?: number | string;
         socket?: net.Socket;
-        pfx?: any;   //string | Buffer
-        key?: any;   //string | Buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;  //string | Buffer
-        ca?: any;    //Array of string | Buffer
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //Array of string | Buffer
+        NPNProtocols?: Array<string | Buffer>;
         servername?: string;
     }
 

--- a/0.12/node.d.ts
+++ b/0.12/node.d.ts
@@ -447,6 +447,55 @@ declare module "http" {
     import * as net from "net";
     import * as stream from "stream";
 
+    /**
+     * Options for http.request()
+    */
+    export interface RequestOptions {
+        /**
+         * A domain name or IP address of the server to issue the request to. Defaults to 'localhost'.
+         */
+        host?: string;
+        /**
+         * To support url.parse() hostname is preferred over host
+         */
+        hostname?: string;
+        /**
+         * Port of remote server. Defaults to 80.
+         */
+        port?: number | string;
+        /**
+         * Local interface to bind for network connections.
+         */
+        localAddress?: string;
+        /**
+         * Unix Domain Socket (use one of host:port or socketPath)
+         */
+        socketPath?: string;
+        /**
+         * A string specifying the HTTP request method. Defaults to 'GET'.
+         */
+        method?: string;
+        /**
+         * Request path. Defaults to '/'. Should include query string if any. E.G. '/index.html?page=12'
+         */
+        path?: string;
+        /**
+         * An object containing request headers.
+         */
+        headers?: { [index: string]: any };
+        /**
+         * Basic authentication i.e. 'user:password' to compute an Authorization header.
+         */
+        auth?: string;
+        /**
+         * Controls Agent behavior. When an Agent is used request will default to Connection: keep-alive. Possible values:
+         * - undefined (default): use global Agent for this host and port.
+         * - Agent object: explicitly use the passed in Agent.
+         * - false: opts out of connection pooling with an Agent, defaults request to Connection: close.
+         */
+        agent?: Agent | boolean;
+    }
+
     export interface Server extends events.EventEmitter {
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
         listen(port: number, hostname?: string, callback?: Function): Server;
@@ -584,8 +633,8 @@ declare module "http" {
     };
     export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
-    export function get(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -728,11 +777,11 @@ declare module "https" {
     import * as http from "http";
 
     export interface ServerOptions {
-        pfx?: any;
-        key?: any;
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         crl?: any;
         ciphers?: string;
         honorCipherOrder?: boolean;
@@ -742,20 +791,12 @@ declare module "https" {
         SNICallback?: (servername: string) => any;
     }
 
-    export interface RequestOptions {
-        host?: string;
-        hostname?: string;
-        port?: number;
-        path?: string;
-        method?: string;
-        headers?: any;
-        auth?: string;
-        agent?: any;
-        pfx?: any;
-        key?: any;
+    export interface RequestOptions extends http.RequestOptions {
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         ciphers?: string;
         rejectUnauthorized?: boolean;
     }
@@ -770,8 +811,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -949,7 +990,7 @@ declare module "url" {
         host?: string;
         pathname?: string;
         search?: string;
-        query?: any; // string | Object
+        query?: string | any;
         slashes?: boolean;
         hash?: string;
         path?: string;
@@ -1519,31 +1560,31 @@ declare module "tls" {
     var CLIENT_RENEG_WINDOW: number;
 
     export interface TlsOptions {
-        pfx?: any;   //string or buffer
-        key?: any;   //string or buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;    //string or buffer
-        crl?: any;   //string or string array
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: any;
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //array or Buffer;
+        NPNProtocols?: Array<string | Buffer>;
         SNICallback?: (servername: string) => any;
     }
 
     export interface ConnectionOptions {
         host?: string;
-        port?: number;
+        port?: number | string;
         socket?: net.Socket;
-        pfx?: any;   //string | Buffer
-        key?: any;   //string | Buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;  //string | Buffer
-        ca?: any;    //Array of string | Buffer
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //Array of string | Buffer
+        NPNProtocols?: Array<string | Buffer>;
         servername?: string;
     }
 
@@ -1588,12 +1629,12 @@ declare module "tls" {
     }
 
     export interface SecureContextOptions {
-        pfx?: any;   //string | buffer
-        key?: any;   //string | buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;  // string | buffer
-        ca?: any;    // string | buffer
-        crl?: any;   // string | string[]
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: boolean;
     }

--- a/4/node.d.ts
+++ b/4/node.d.ts
@@ -612,14 +612,14 @@ declare module "http" {
         host?: string;
         hostname?: string;
         family?: number;
-        port?: number;
+        port?: number | string;
         localAddress?: string;
         socketPath?: string;
         method?: string;
         path?: string;
         headers?: { [key: string]: any };
         auth?: string;
-        agent?: Agent|boolean;
+        agent?: Agent | boolean;
     }
 
     export interface Server extends events.EventEmitter, net.Server {
@@ -761,8 +761,8 @@ declare module "http" {
     };
     export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
-    export function get(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -959,11 +959,11 @@ declare module "https" {
     }
 
     export interface RequestOptions extends http.RequestOptions {
-        pfx?: any;
-        key?: any;
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         ciphers?: string;
         rejectUnauthorized?: boolean;
         secureProtocol?: string;
@@ -980,8 +980,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -1884,32 +1884,32 @@ declare module "tls" {
 
     export interface TlsOptions {
         host?: string;
-        port?: number;
-        pfx?: any;   //string or buffer
-        key?: any;   //string or buffer
+        port?: string | number;
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;    //string or buffer
-        crl?: any;   //string or string array
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: any;
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //array or Buffer;
+        NPNProtocols?: Array<string | Buffer>;
         SNICallback?: (servername: string) => any;
     }
 
     export interface ConnectionOptions {
         host?: string;
-        port?: number;
+        port?: number | string;
         socket?: net.Socket;
-        pfx?: string | Buffer
-        key?: string | Buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: string | Buffer
-        ca?: (string | Buffer)[];
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: (string | Buffer)[];
+        NPNProtocols?: Array<string | Buffer>;
         servername?: string;
     }
 
@@ -1949,11 +1949,11 @@ declare module "tls" {
 
     export interface SecureContextOptions {
         pfx?: string | Buffer;
-        key?: string | Buffer;
+        key?: string | string[] | Buffer | Array<{ pem: string, passphrase: string }>;
         passphrase?: string;
         cert?: string | Buffer;
         ca?: string | Buffer;
-        crl?: string | string[]
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: boolean;
     }

--- a/6/node.d.ts
+++ b/6/node.d.ts
@@ -612,7 +612,7 @@ declare module "http" {
         host?: string;
         hostname?: string;
         family?: number;
-        port?: number;
+        port?: number | string;
         localAddress?: string;
         socketPath?: string;
         method?: string;
@@ -761,8 +761,8 @@ declare module "http" {
     };
     export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) => void): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
-    export function get(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -959,11 +959,11 @@ declare module "https" {
     }
 
     export interface RequestOptions extends http.RequestOptions {
-        pfx?: any;
-        key?: any;
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         ciphers?: string;
         rejectUnauthorized?: boolean;
         secureProtocol?: string;
@@ -980,8 +980,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
+    export function request(options: string | RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
+    export function get(options: string | RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -1885,32 +1885,32 @@ declare module "tls" {
 
     export interface TlsOptions {
         host?: string;
-        port?: number;
-        pfx?: any;   //string or buffer
-        key?: any;   //string or buffer
+        port?: number | string;
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: any;
-        ca?: any;    //string or buffer
-        crl?: any;   //string or string array
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: any;
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: any;  //array or Buffer;
+        NPNProtocols?: Array<string | Buffer>;
         SNICallback?: (servername: string) => any;
     }
 
     export interface ConnectionOptions {
         host?: string;
-        port?: number;
+        port?: number | string;
         socket?: net.Socket;
-        pfx?: string | Buffer
-        key?: string | Buffer
+        pfx?: string | Buffer;
+        key?: string | Buffer;
         passphrase?: string;
-        cert?: string | Buffer
-        ca?: (string | Buffer)[];
+        cert?: string | Buffer;
+        ca?: string | Buffer | Array<string | Buffer>;
         rejectUnauthorized?: boolean;
-        NPNProtocols?: (string | Buffer)[];
+        NPNProtocols?: Array<string | Buffer>;
         servername?: string;
     }
 
@@ -1950,11 +1950,11 @@ declare module "tls" {
 
     export interface SecureContextOptions {
         pfx?: string | Buffer;
-        key?: string | Buffer;
+        key?: string | string[] | Buffer | Array<{ pem: string, passphrase: string }>;
         passphrase?: string;
         cert?: string | Buffer;
         ca?: string | Buffer;
-        crl?: string | string[]
+        crl?: string | string[];
         ciphers?: string;
         honorCipherOrder?: boolean;
     }


### PR DESCRIPTION
What started out as adding `string` to the `port` time turned into an update of many types related to connection handling. Including making them more consistent with each other.