### PR TITLE
ServerResponse end() only takes a string or Buffer

### DIFF
--- a/0.10/node.d.ts
+++ b/0.10/node.d.ts
@@ -334,7 +334,6 @@ declare module "http" {
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
-        end(data?: any, encoding?: string): void;
     }
 
 	/**

--- a/0.11/node.d.ts
+++ b/0.11/node.d.ts
@@ -383,7 +383,6 @@ declare module "http" {
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
-        end(data?: any, encoding?: string): void;
     }
     export interface ClientRequest extends events.EventEmitter, stream.Writable {
         // Extended base methods

--- a/0.12/node.d.ts
+++ b/0.12/node.d.ts
@@ -536,7 +536,6 @@ declare module "http" {
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
-        end(data?: any, encoding?: string): void;
     }
     export interface ClientRequest extends events.EventEmitter, stream.Writable {
         // Extended base methods

--- a/4/node.d.ts
+++ b/4/node.d.ts
@@ -659,7 +659,6 @@ declare module "http" {
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
-        end(data?: any, encoding?: string): void;
     }
     export interface ClientRequest extends events.EventEmitter, stream.Writable {
         // Extended base methods

--- a/6/node.d.ts
+++ b/6/node.d.ts
@@ -659,7 +659,6 @@ declare module "http" {
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
-        end(data?: any, encoding?: string): void;
     }
     export interface ClientRequest extends events.EventEmitter, stream.Writable {
         // Extended base methods


### PR DESCRIPTION
If you call `end` with anything other than a string or Buffer as first argument

```javascript
res.end({
  hello: 'world'
});
```

It passes the type check but blows up at runtime

> TypeError: First argument must be a string or Buffer
>     at ServerResponse.OutgoingMessage.end (_http_outgoing.js:542:11)