### PR TITLE
Adding ReadableStream isPaused()

### DIFF
--- a/4/node.d.ts
+++ b/4/node.d.ts
@@ -311,6 +311,7 @@ declare namespace NodeJS {
         read(size?: number): string|Buffer;
         setEncoding(encoding: string): void;
         pause(): void;
+        isPaused(): boolean;
         resume(): void;
         pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends WritableStream>(destination?: T): void;
@@ -2084,6 +2085,7 @@ declare module "stream" {
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
+        isPaused(): boolean;
         resume(): void;
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends NodeJS.WritableStream>(destination?: T): void;
@@ -2137,6 +2139,7 @@ declare module "stream" {
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
+        isPaused(): boolean;
         resume(): void;
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends NodeJS.WritableStream>(destination?: T): void;

--- a/6/node.d.ts
+++ b/6/node.d.ts
@@ -310,6 +310,7 @@ declare namespace NodeJS {
         readable: boolean;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string): void;
+        isPaused(): boolean;
         pause(): void;
         resume(): void;
         pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
@@ -2085,6 +2086,7 @@ declare module "stream" {
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
+        isPaused(): boolean;
         resume(): void;
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends NodeJS.WritableStream>(destination?: T): void;
@@ -2138,6 +2140,7 @@ declare module "stream" {
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
+        isPaused(): boolean;
         resume(): void;
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends NodeJS.WritableStream>(destination?: T): void;


### PR DESCRIPTION
ReadableStreams implemented `isPaused` (6.3 documentation here -- https://nodejs.org/api/stream.html#stream_readable_ispaused)

Added to ReadableStreams, Readable and Transform interfaces.  

Let me know if I need to do anything else.